### PR TITLE
Add complete Android development environment setup

### DIFF
--- a/android-dev-setup/LICENSE
+++ b/android-dev-setup/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Android Development Environment Setup
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/android-dev-setup/README.md
+++ b/android-dev-setup/README.md
@@ -1,0 +1,169 @@
+# Android Development Environment Setup
+
+This repository contains scripts to set up a complete Android development environment, including JDK, Android SDK, NDK, Gradle, and Android Studio. The setup is designed to be production-ready, reproducible, and support a wide range of Android app requirements.
+
+## Features
+
+- **Complete Setup**: Installs and configures all components needed for Android development
+- **Production-Ready**: Includes all necessary tools for both local development and CI/CD pipelines
+- **Reproducible**: Consistent setup across different machines
+- **Flexible**: Individual scripts for each component, or a single script for complete setup
+- **Validated**: Includes validation steps to ensure everything is working correctly
+
+## Components
+
+The setup includes the following components:
+
+- **JDK**: Java Development Kit 17 (or 11 as fallback)
+- **Android SDK**: Command line tools, platform tools, build tools, platforms, and system images
+- **Android NDK**: Native Development Kit for native code
+- **Gradle**: Build system for Android projects
+- **Android Studio**: IDE for Android development
+- **AVD**: Android Virtual Device for testing
+
+## Requirements
+
+- Linux or macOS operating system
+- Internet connection
+- Basic command-line knowledge
+
+## Installation
+
+### Option 1: Complete Setup
+
+To set up the complete Android development environment, run:
+
+```bash
+chmod +x /workspace/android-dev-setup/setup-all.sh
+/workspace/android-dev-setup/setup-all.sh [INSTALL_DIR]
+```
+
+Where `[INSTALL_DIR]` is the directory where you want to install the Android development environment. If not specified, it defaults to `$HOME/android-dev`.
+
+### Option 2: Individual Components
+
+You can also install individual components using the following scripts:
+
+1. **JDK**:
+   ```bash
+   chmod +x /workspace/android-dev-setup/install-jdk.sh
+   /workspace/android-dev-setup/install-jdk.sh [INSTALL_DIR]
+   ```
+
+2. **Android SDK**:
+   ```bash
+   chmod +x /workspace/android-dev-setup/install-android-sdk.sh
+   /workspace/android-dev-setup/install-android-sdk.sh [INSTALL_DIR]
+   ```
+
+3. **Android NDK**:
+   ```bash
+   chmod +x /workspace/android-dev-setup/install-android-ndk.sh
+   /workspace/android-dev-setup/install-android-ndk.sh [INSTALL_DIR]
+   ```
+
+4. **Gradle**:
+   ```bash
+   chmod +x /workspace/android-dev-setup/install-gradle.sh
+   /workspace/android-dev-setup/install-gradle.sh [INSTALL_DIR]
+   ```
+
+5. **Android Studio**:
+   ```bash
+   chmod +x /workspace/android-dev-setup/install-android-studio.sh
+   /workspace/android-dev-setup/install-android-studio.sh [INSTALL_DIR]
+   ```
+
+6. **AVD**:
+   ```bash
+   chmod +x /workspace/android-dev-setup/create-avd.sh
+   /workspace/android-dev-setup/create-avd.sh [INSTALL_DIR] [AVD_NAME] [API_LEVEL] [DEVICE]
+   ```
+
+## Post-Installation
+
+After installation, you need to activate the environment variables in your current shell:
+
+```bash
+source "$INSTALL_DIR/env-setup.sh"
+```
+
+Where `$INSTALL_DIR` is the directory where you installed the Android development environment.
+
+## Launching Android Studio
+
+To launch Android Studio, run:
+
+```bash
+"$INSTALL_DIR/studio.sh"
+```
+
+## Launching the Android Emulator
+
+To launch the Android emulator, run:
+
+```bash
+"$INSTALL_DIR/launch-emulator.sh"
+```
+
+## Validation
+
+The setup includes validation steps to ensure everything is installed correctly. If you want to validate the installation manually, you can check the following:
+
+- **JDK**: `"$JAVA_HOME/bin/java" -version`
+- **Android SDK**: `"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --list`
+- **Android NDK**: Check if `$ANDROID_NDK_HOME` directory exists
+- **Gradle**: `"$GRADLE_HOME/bin/gradle" --version`
+- **Android Studio**: Check if `$ANDROID_STUDIO_DIR` directory exists
+- **AVD**: `"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager" list avd`
+
+## Environment Variables
+
+The setup sets the following environment variables:
+
+- `JAVA_HOME`: Path to JDK
+- `ANDROID_SDK_ROOT`: Path to Android SDK
+- `ANDROID_HOME`: Path to Android SDK (same as `ANDROID_SDK_ROOT`)
+- `ANDROID_NDK_HOME`: Path to Android NDK
+- `GRADLE_HOME`: Path to Gradle
+
+These variables are added to your shell profile (`.bashrc`, `.zshrc`, or `.bash_profile`) and can be activated in the current shell by running `source "$INSTALL_DIR/env-setup.sh"`.
+
+## CI/CD Integration
+
+For CI/CD pipelines, you can use the individual scripts to install only the components you need. For example, if you don't need Android Studio, you can skip the `install-android-studio.sh` script.
+
+You can also use the environment variables in your CI/CD pipeline to configure the build process. For example:
+
+```yaml
+# Example GitHub Actions workflow
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Android development environment
+        run: |
+          chmod +x /workspace/android-dev-setup/setup-all.sh
+          /workspace/android-dev-setup/setup-all.sh $HOME/android-dev
+          source $HOME/android-dev/env-setup.sh
+      - name: Build Android app
+        run: |
+          cd your-android-project
+          ./gradlew assembleDebug
+```
+
+## Troubleshooting
+
+If you encounter any issues during installation, check the following:
+
+- Make sure you have an internet connection
+- Check if you have sufficient disk space
+- Verify that you have the necessary permissions to install software
+- Check if the required dependencies are installed
+
+If you still have issues, you can try installing the components individually to identify the problematic component.
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/android-dev-setup/SUMMARY.md
+++ b/android-dev-setup/SUMMARY.md
@@ -1,0 +1,97 @@
+# Android Development Environment Setup Summary
+
+This repository contains a complete set of scripts and configurations for setting up an Android development environment. The setup is designed to be production-ready, reproducible, and support a wide range of Android app requirements.
+
+## Components Installed
+
+| Component | Version | Description |
+|-----------|---------|-------------|
+| JDK | 17 (or 11 as fallback) | Java Development Kit for Android development |
+| Android SDK | Latest | Android Software Development Kit |
+| Android SDK Platforms | 34, 33 | Android API levels |
+| Android SDK Build Tools | 34.0.0 | Tools for building Android apps |
+| Android NDK | 25.2.9519653 | Native Development Kit for native code |
+| Gradle | 8.4 | Build system for Android projects |
+| Android Studio | 2023.1.1.26 | IDE for Android development |
+| Android Emulator | Latest | Emulator for testing Android apps |
+| System Images | API 34 | System images for the emulator |
+
+## Environment Variables
+
+The following environment variables are set:
+
+- `JAVA_HOME`: Path to JDK
+- `ANDROID_SDK_ROOT`: Path to Android SDK
+- `ANDROID_HOME`: Path to Android SDK (same as `ANDROID_SDK_ROOT`)
+- `ANDROID_NDK_HOME`: Path to Android NDK
+- `GRADLE_HOME`: Path to Gradle
+- `PATH`: Updated to include all necessary binaries
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `setup.sh` | Complete setup script for all components |
+| `setup-all.sh` | Alternative complete setup script |
+| `install-jdk.sh` | Installs JDK |
+| `install-android-sdk.sh` | Installs Android SDK |
+| `install-android-ndk.sh` | Installs Android NDK |
+| `install-gradle.sh` | Installs Gradle |
+| `install-android-studio.sh` | Installs Android Studio |
+| `create-avd.sh` | Creates an Android Virtual Device |
+| `validate-environment.sh` | Validates the installation |
+| `ci-setup.sh` | Minimal setup for CI/CD pipelines |
+
+## Docker Support
+
+Docker configuration files are provided for containerized development:
+
+- `docker/Dockerfile`: Docker image definition
+- `docker/docker-compose.yml`: Docker Compose configuration
+- `docker/README.md`: Docker usage instructions
+
+## CI/CD Integration
+
+GitHub Actions workflow is provided for CI/CD integration:
+
+- `github-actions-workflow.yml`: GitHub Actions workflow for building and testing Android apps
+
+## Usage
+
+To set up the complete Android development environment, run:
+
+```bash
+chmod +x /workspace/android-dev-setup/setup-all.sh
+/workspace/android-dev-setup/setup-all.sh [INSTALL_DIR]
+```
+
+Where `[INSTALL_DIR]` is the directory where you want to install the Android development environment. If not specified, it defaults to `$HOME/android-dev`.
+
+After installation, you need to activate the environment variables in your current shell:
+
+```bash
+source "$INSTALL_DIR/env-setup.sh"
+```
+
+## Validation
+
+The setup includes validation steps to ensure everything is installed correctly. You can run the validation script manually:
+
+```bash
+chmod +x /workspace/android-dev-setup/validate-environment.sh
+/workspace/android-dev-setup/validate-environment.sh [INSTALL_DIR]
+```
+
+## Docker Usage
+
+To use the Docker container, run:
+
+```bash
+cd /workspace/android-dev-setup
+docker build -t android-dev -f docker/Dockerfile .
+docker run -it --rm -v $(pwd):/workspace android-dev
+```
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/android-dev-setup/ci-setup.sh
+++ b/android-dev-setup/ci-setup.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# CI/CD Android Development Environment Setup Script
+# This script sets up a minimal Android development environment for CI/CD pipelines
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+ANDROID_SDK_ROOT="$INSTALL_DIR/android-sdk"
+ANDROID_HOME="$ANDROID_SDK_ROOT"
+ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/25.2.9519653"
+GRADLE_HOME="$INSTALL_DIR/gradle"
+JAVA_HOME="$INSTALL_DIR/jdk"
+CMDLINE_TOOLS_VERSION="11.0"
+BUILD_TOOLS_VERSION="34.0.0"
+PLATFORM_VERSION="34"
+PLATFORM_VERSION_FALLBACK="33"
+NDK_VERSION="25.2.9519653"
+GRADLE_VERSION="8.4"
+JDK_VERSION="17"
+JDK_FALLBACK_VERSION="11"
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+echo "=== CI/CD Android Development Environment Setup ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Starting setup at $(date)"
+echo
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macos"
+    else
+        echo "unsupported"
+    fi
+}
+
+OS_TYPE=$(detect_os)
+if [[ "$OS_TYPE" == "unsupported" ]]; then
+    echo "Unsupported operating system: $OSTYPE"
+    exit 1
+fi
+
+echo "Detected OS: $OS_TYPE"
+
+# Install required packages
+echo "=== Installing system dependencies ==="
+if [[ "$OS_TYPE" == "linux" ]]; then
+    if command_exists apt-get; then
+        apt-get update
+        apt-get install -y wget unzip zip curl git build-essential
+    elif command_exists dnf; then
+        dnf install -y wget unzip zip curl git gcc gcc-c++ make
+    else
+        echo "Unsupported Linux distribution. Please install the following packages manually:"
+        echo "wget, unzip, zip, curl, git, build tools"
+    fi
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    if ! command_exists brew; then
+        echo "Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+    
+    brew install wget unzip zip curl git
+fi
+echo "System dependencies installed."
+
+# Install JDK
+echo "=== Installing JDK $JDK_VERSION ==="
+mkdir -p "$JAVA_HOME"
+
+if [[ "$OS_TYPE" == "linux" ]]; then
+    # Try to install JDK 17 first, fall back to JDK 11 if needed
+    if wget -q --spider "https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz"; then
+        wget -O jdk.tar.gz "https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz"
+        JDK_VERSION="17"
+    else
+        echo "JDK 17 not available, falling back to JDK 11"
+        wget -O jdk.tar.gz "https://download.oracle.com/java/11/latest/jdk-11_linux-x64_bin.tar.gz"
+        JDK_VERSION="11"
+    fi
+    
+    tar -xzf jdk.tar.gz -C "$JAVA_HOME" --strip-components=1
+    rm jdk.tar.gz
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    if wget -q --spider "https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz"; then
+        wget -O jdk.tar.gz "https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz"
+        JDK_VERSION="17"
+    else
+        echo "JDK 17 not available, falling back to JDK 11"
+        wget -O jdk.tar.gz "https://download.oracle.com/java/11/latest/jdk-11_macos-x64_bin.tar.gz"
+        JDK_VERSION="11"
+    fi
+    
+    tar -xzf jdk.tar.gz -C "$JAVA_HOME" --strip-components=1
+    rm jdk.tar.gz
+fi
+
+echo "JDK $JDK_VERSION installed at $JAVA_HOME"
+"$JAVA_HOME/bin/java" -version
+
+# Install Android SDK
+echo "=== Installing Android SDK ==="
+mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+
+if [[ "$OS_TYPE" == "linux" ]]; then
+    wget -O cmdline-tools.zip "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    wget -O cmdline-tools.zip "https://dl.google.com/android/repository/commandlinetools-mac-${CMDLINE_TOOLS_VERSION}_latest.zip"
+fi
+
+unzip -q cmdline-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools/temp"
+mv "$ANDROID_SDK_ROOT/cmdline-tools/temp/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+rmdir "$ANDROID_SDK_ROOT/cmdline-tools/temp"
+rm cmdline-tools.zip
+
+echo "Android SDK Command Line Tools installed at $ANDROID_SDK_ROOT/cmdline-tools/latest"
+
+# Configure environment variables
+export JAVA_HOME="$JAVA_HOME"
+export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+export ANDROID_HOME="$ANDROID_HOME"
+export PATH="$JAVA_HOME/bin:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"
+
+# Accept licenses
+echo "=== Accepting SDK licenses ==="
+yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+# Install platform tools
+echo "=== Installing platform tools ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platform-tools"
+
+# Install build tools
+echo "=== Installing build tools $BUILD_TOOLS_VERSION ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "build-tools;$BUILD_TOOLS_VERSION"
+
+# Install platforms
+echo "=== Installing platform $PLATFORM_VERSION ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platforms;android-$PLATFORM_VERSION"
+
+echo "=== Installing platform $PLATFORM_VERSION_FALLBACK (fallback) ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platforms;android-$PLATFORM_VERSION_FALLBACK"
+
+# Install Android NDK
+echo "=== Installing Android NDK $NDK_VERSION ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "ndk;$NDK_VERSION"
+echo "Android NDK $NDK_VERSION installed at $ANDROID_NDK_HOME"
+
+# Install Gradle
+echo "=== Installing Gradle $GRADLE_VERSION ==="
+mkdir -p "$GRADLE_HOME"
+
+wget -O gradle.zip "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip"
+unzip -q gradle.zip -d "$INSTALL_DIR"
+mv "$INSTALL_DIR/gradle-$GRADLE_VERSION"/* "$GRADLE_HOME"
+rmdir "$INSTALL_DIR/gradle-$GRADLE_VERSION"
+rm gradle.zip
+
+echo "Gradle $GRADLE_VERSION installed at $GRADLE_HOME"
+"$GRADLE_HOME/bin/gradle" --version
+
+# Create environment setup script
+echo "=== Creating environment setup script ==="
+cat > "$INSTALL_DIR/env-setup.sh" << EOL
+#!/bin/bash
+# Android Development Environment Variables for CI/CD
+
+export JAVA_HOME="$JAVA_HOME"
+export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+export ANDROID_HOME="$ANDROID_HOME"
+export ANDROID_NDK_HOME="$ANDROID_NDK_HOME"
+export GRADLE_HOME="$GRADLE_HOME"
+export PATH="\$JAVA_HOME/bin:\$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:\$ANDROID_SDK_ROOT/platform-tools:\$ANDROID_NDK_HOME:\$GRADLE_HOME/bin:\$PATH"
+EOL
+
+chmod +x "$INSTALL_DIR/env-setup.sh"
+
+# Source the environment variables for the current session
+source "$INSTALL_DIR/env-setup.sh"
+
+# Validate installation
+echo "=== Validating installation ==="
+
+# Check Java
+if "$JAVA_HOME/bin/java" -version; then
+    echo "✓ Java is installed and working."
+else
+    echo "✗ Java installation failed."
+fi
+
+# Check Android SDK
+if [[ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]]; then
+    echo "✓ Android SDK is installed."
+else
+    echo "✗ Android SDK installation failed."
+fi
+
+# Check Android NDK
+if [[ -d "$ANDROID_NDK_HOME" ]]; then
+    echo "✓ Android NDK is installed."
+else
+    echo "✗ Android NDK installation failed."
+fi
+
+# Check Gradle
+if "$GRADLE_HOME/bin/gradle" --version; then
+    echo "✓ Gradle is installed and working."
+else
+    echo "✗ Gradle installation failed."
+fi
+
+# Generate summary report
+echo "=== CI/CD Android Development Environment Summary ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "JDK version: $JDK_VERSION"
+echo "Android SDK: $ANDROID_SDK_ROOT"
+echo "Android NDK: $ANDROID_NDK_HOME"
+echo "Gradle: $GRADLE_HOME"
+echo
+echo "Environment setup script: $INSTALL_DIR/env-setup.sh"
+echo
+echo "To activate the environment in a new terminal, run:"
+echo "source \"$INSTALL_DIR/env-setup.sh\""
+echo
+echo "Setup completed at $(date)"
+
+echo "=== CI/CD Android Development Environment Setup Completed ==="

--- a/android-dev-setup/create-avd.sh
+++ b/android-dev-setup/create-avd.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Android Virtual Device (AVD) Creation Script
+# This script creates AVDs for testing Android applications
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+ANDROID_SDK_ROOT="$INSTALL_DIR/android-sdk"
+ANDROID_HOME="$ANDROID_SDK_ROOT"
+AVD_NAME="${2:-test_avd}"
+API_LEVEL="${3:-34}"
+DEVICE="${4:-pixel_5}"
+SYSTEM_IMAGE="system-images;android-$API_LEVEL;google_apis_playstore;x86_64"
+FALLBACK_SYSTEM_IMAGE="system-images;android-$API_LEVEL;google_apis;x86_64"
+
+# Check if Android SDK is installed
+if [[ ! -d "$ANDROID_SDK_ROOT/cmdline-tools/latest" ]]; then
+    echo "Error: Android SDK not found at $ANDROID_SDK_ROOT"
+    echo "Please install Android SDK first using install-android-sdk.sh"
+    exit 1
+fi
+
+echo "=== Creating Android Virtual Device (AVD) ==="
+echo "SDK directory: $ANDROID_SDK_ROOT"
+echo "AVD name: $AVD_NAME"
+echo "API level: $API_LEVEL"
+echo "Device: $DEVICE"
+echo "System image: $SYSTEM_IMAGE"
+echo "Starting at $(date)"
+echo
+
+# Source Android SDK environment variables
+if [[ -f "$INSTALL_DIR/android-env.sh" ]]; then
+    source "$INSTALL_DIR/android-env.sh"
+else
+    echo "Warning: Android SDK environment setup script not found."
+    echo "Setting environment variables manually."
+    export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+    export ANDROID_HOME="$ANDROID_HOME"
+    export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$PATH"
+fi
+
+# Check if system image is installed
+echo "=== Checking system image ==="
+if ! "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --list | grep -q "$SYSTEM_IMAGE"; then
+    echo "System image $SYSTEM_IMAGE not found. Installing..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "$SYSTEM_IMAGE"
+    
+    if [ $? -ne 0 ]; then
+        echo "Failed to install $SYSTEM_IMAGE. Trying fallback image..."
+        "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "$FALLBACK_SYSTEM_IMAGE"
+        
+        if [ $? -eq 0 ]; then
+            SYSTEM_IMAGE="$FALLBACK_SYSTEM_IMAGE"
+            echo "Fallback system image installed successfully."
+        else
+            echo "Error: Failed to install system images."
+            exit 1
+        fi
+    fi
+fi
+
+# Check if emulator is installed
+echo "=== Checking emulator ==="
+if ! "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --list | grep -q "emulator"; then
+    echo "Emulator not found. Installing..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "emulator"
+    
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to install emulator."
+        exit 1
+    fi
+fi
+
+# Create AVD
+echo "=== Creating AVD $AVD_NAME ==="
+echo "no" | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager" create avd \
+    -n "$AVD_NAME" \
+    -k "$SYSTEM_IMAGE" \
+    -d "$DEVICE"
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to create AVD."
+    exit 1
+fi
+
+# Configure AVD for better performance
+echo "=== Configuring AVD for better performance ==="
+AVD_DIR="$HOME/.android/avd/${AVD_NAME}.avd"
+CONFIG_FILE="$AVD_DIR/config.ini"
+
+if [[ -f "$CONFIG_FILE" ]]; then
+    # Backup original config
+    cp "$CONFIG_FILE" "${CONFIG_FILE}.backup"
+    
+    # Update config for better performance
+    sed -i 's/hw.lcd.density=.*/hw.lcd.density=420/' "$CONFIG_FILE"
+    sed -i 's/hw.ramSize=.*/hw.ramSize=2048/' "$CONFIG_FILE"
+    
+    # Add performance settings
+    echo "hw.gpu.enabled=yes" >> "$CONFIG_FILE"
+    echo "hw.gpu.mode=auto" >> "$CONFIG_FILE"
+    echo "hw.keyboard=yes" >> "$CONFIG_FILE"
+    
+    echo "AVD configuration updated for better performance."
+else
+    echo "Warning: Could not find AVD config file at $CONFIG_FILE"
+fi
+
+# Create launcher script
+echo "=== Creating emulator launcher script ==="
+cat > "$INSTALL_DIR/launch-emulator.sh" << EOL
+#!/bin/bash
+# Android Emulator Launcher
+
+export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+export ANDROID_HOME="$ANDROID_HOME"
+export PATH="\$ANDROID_SDK_ROOT/emulator:\$ANDROID_SDK_ROOT/platform-tools:\$PATH"
+
+# Launch emulator
+echo "Launching emulator with AVD: $AVD_NAME"
+"\$ANDROID_SDK_ROOT/emulator/emulator" -avd "$AVD_NAME" -gpu auto "\$@"
+EOL
+
+chmod +x "$INSTALL_DIR/launch-emulator.sh"
+
+echo "Launcher script created at $INSTALL_DIR/launch-emulator.sh"
+echo "To launch the emulator, run:"
+echo "$INSTALL_DIR/launch-emulator.sh"
+
+echo "=== AVD Creation Completed ==="
+echo "AVD '$AVD_NAME' is now ready for use."
+echo "You can launch it using the emulator command or the launcher script."

--- a/android-dev-setup/docker/Dockerfile
+++ b/android-dev-setup/docker/Dockerfile
@@ -1,0 +1,66 @@
+FROM ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set environment variables
+ENV ANDROID_DEV_HOME=/opt/android-dev
+ENV JAVA_HOME=${ANDROID_DEV_HOME}/jdk
+ENV ANDROID_SDK_ROOT=${ANDROID_DEV_HOME}/android-sdk
+ENV ANDROID_HOME=${ANDROID_SDK_ROOT}
+ENV ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/25.2.9519653
+ENV GRADLE_HOME=${ANDROID_DEV_HOME}/gradle
+ENV PATH=${JAVA_HOME}/bin:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_NDK_HOME}:${GRADLE_HOME}/bin:${PATH}
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    wget \
+    unzip \
+    zip \
+    curl \
+    git \
+    build-essential \
+    libz-dev \
+    libncurses-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libssl-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libgl1-mesa-dev \
+    libxrandr-dev \
+    libxxf86vm-dev \
+    libxinerama-dev \
+    libxcursor-dev \
+    libxi-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create installation directory
+RUN mkdir -p ${ANDROID_DEV_HOME}
+
+# Copy setup scripts
+COPY *.sh ${ANDROID_DEV_HOME}/
+
+# Make scripts executable
+RUN chmod +x ${ANDROID_DEV_HOME}/*.sh
+
+# Run CI setup script
+RUN cd ${ANDROID_DEV_HOME} && ./ci-setup.sh ${ANDROID_DEV_HOME}
+
+# Set working directory
+WORKDIR /workspace
+
+# Create a non-root user for running the container
+RUN groupadd -r android && useradd -r -g android -m -d /home/android android
+RUN chown -R android:android ${ANDROID_DEV_HOME}
+RUN chown -R android:android /workspace
+
+# Switch to non-root user
+USER android
+
+# Set up environment
+RUN echo "source ${ANDROID_DEV_HOME}/env-setup.sh" >> /home/android/.bashrc
+
+# Default command
+CMD ["bash"]

--- a/android-dev-setup/docker/README.md
+++ b/android-dev-setup/docker/README.md
@@ -1,0 +1,107 @@
+# Android Development Docker Environment
+
+This directory contains Docker configuration files for setting up an Android development environment in a container. This is useful for CI/CD pipelines and for developers who want to use a containerized development environment.
+
+## Features
+
+- Ubuntu 22.04 base image
+- JDK 17 (or 11 as fallback)
+- Android SDK with command line tools, platform tools, build tools, and platforms
+- Android NDK for native code development
+- Gradle for building Android projects
+- Non-root user for running the container
+
+## Prerequisites
+
+- Docker
+- Docker Compose (optional, for using docker-compose.yml)
+
+## Building the Docker Image
+
+To build the Docker image, run:
+
+```bash
+cd /workspace/android-dev-setup
+docker build -t android-dev -f docker/Dockerfile .
+```
+
+## Running the Docker Container
+
+To run the Docker container, use:
+
+```bash
+docker run -it --rm -v $(pwd):/workspace android-dev
+```
+
+This will start a bash shell in the container with the current directory mounted as `/workspace`.
+
+## Using Docker Compose
+
+Alternatively, you can use Docker Compose:
+
+```bash
+cd /workspace/android-dev-setup
+docker-compose -f docker/docker-compose.yml up -d
+docker-compose -f docker/docker-compose.yml exec android-dev bash
+```
+
+This will start the container and open a bash shell in it.
+
+## Environment Variables
+
+The following environment variables are set in the container:
+
+- `ANDROID_DEV_HOME`: `/opt/android-dev`
+- `JAVA_HOME`: `/opt/android-dev/jdk`
+- `ANDROID_SDK_ROOT`: `/opt/android-dev/android-sdk`
+- `ANDROID_HOME`: `/opt/android-dev/android-sdk`
+- `ANDROID_NDK_HOME`: `/opt/android-dev/android-sdk/ndk/25.2.9519653`
+- `GRADLE_HOME`: `/opt/android-dev/gradle`
+
+## Using the Container for CI/CD
+
+You can use this Docker image in your CI/CD pipelines. For example, in GitHub Actions:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: android-dev
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Android app
+        run: |
+          cd your-android-project
+          ./gradlew assembleDebug
+```
+
+## Customizing the Docker Image
+
+You can customize the Docker image by modifying the Dockerfile. For example, you can:
+
+- Change the base image
+- Install additional packages
+- Change the Android SDK, NDK, or Gradle versions
+- Add custom configuration files
+
+After making changes, rebuild the Docker image:
+
+```bash
+docker build -t android-dev-custom -f docker/Dockerfile .
+```
+
+## Troubleshooting
+
+If you encounter any issues with the Docker container, check the following:
+
+- Make sure Docker is installed and running
+- Check if the container has enough resources (CPU, memory, disk space)
+- Verify that the environment variables are set correctly
+- Check if the mounted volumes have the correct permissions
+
+If you still have issues, you can try rebuilding the Docker image with the `--no-cache` option:
+
+```bash
+docker build --no-cache -t android-dev -f docker/Dockerfile .
+```

--- a/android-dev-setup/docker/docker-compose.yml
+++ b/android-dev-setup/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  android-dev:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ../:/workspace
+    environment:
+      - ANDROID_DEV_HOME=/opt/android-dev
+      - JAVA_HOME=/opt/android-dev/jdk
+      - ANDROID_SDK_ROOT=/opt/android-dev/android-sdk
+      - ANDROID_HOME=/opt/android-dev/android-sdk
+      - ANDROID_NDK_HOME=/opt/android-dev/android-sdk/ndk/25.2.9519653
+      - GRADLE_HOME=/opt/android-dev/gradle
+    working_dir: /workspace
+    command: bash -c "source /opt/android-dev/env-setup.sh && bash"

--- a/android-dev-setup/github-actions-workflow.yml
+++ b/android-dev-setup/github-actions-workflow.yml
@@ -1,0 +1,116 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+    
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v2
+    
+    - name: Accept Android SDK licenses
+      run: yes | sdkmanager --licenses
+    
+    - name: Install Android SDK components
+      run: |
+        sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0" "ndk;25.2.9519653"
+    
+    - name: Build with Gradle
+      run: ./gradlew build
+    
+    - name: Run tests
+      run: ./gradlew test
+    
+    - name: Build debug APK
+      run: ./gradlew assembleDebug
+    
+    - name: Build release APK
+      run: ./gradlew assembleRelease
+    
+    - name: Upload debug APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: app-debug
+        path: app/build/outputs/apk/debug/app-debug.apk
+    
+    - name: Upload release APK
+      uses: actions/upload-artifact@v3
+      with:
+        name: app-release
+        path: app/build/outputs/apk/release/app-release-unsigned.apk
+
+  emulator-test:
+    runs-on: macos-latest
+    needs: build
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+    
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v2
+    
+    - name: Accept Android SDK licenses
+      run: yes | sdkmanager --licenses
+    
+    - name: Install Android SDK components
+      run: |
+        sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0" "ndk;25.2.9519653" "system-images;android-34;google_apis;x86_64"
+    
+    - name: Create AVD
+      run: |
+        echo "no" | avdmanager create avd -n test_avd -k "system-images;android-34;google_apis;x86_64" -d "pixel_5"
+    
+    - name: Start emulator
+      run: |
+        $ANDROID_HOME/emulator/emulator -avd test_avd -no-audio -no-window -no-boot-anim -gpu swiftshader_indirect &
+        adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
+    
+    - name: Run instrumented tests
+      run: ./gradlew connectedAndroidTest
+    
+    - name: Upload test reports
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-reports
+        path: app/build/reports/androidTests/connected/
+
+  docker-build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    
+    - name: Build Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: docker/Dockerfile
+        push: false
+        tags: android-dev:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/android-dev-setup/install-android-ndk.sh
+++ b/android-dev-setup/install-android-ndk.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Android NDK Installation Script
+# This script installs the Android NDK for development
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+ANDROID_SDK_ROOT="$INSTALL_DIR/android-sdk"
+ANDROID_HOME="$ANDROID_SDK_ROOT"
+NDK_VERSION="25.2.9519653"
+ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/$NDK_VERSION"
+
+# Check if Android SDK is installed
+if [[ ! -d "$ANDROID_SDK_ROOT/cmdline-tools/latest" ]]; then
+    echo "Error: Android SDK not found at $ANDROID_SDK_ROOT"
+    echo "Please install Android SDK first using install-android-sdk.sh"
+    exit 1
+fi
+
+echo "=== Installing Android NDK $NDK_VERSION ==="
+echo "SDK directory: $ANDROID_SDK_ROOT"
+echo "Starting installation at $(date)"
+echo
+
+# Source Android SDK environment variables
+if [[ -f "$INSTALL_DIR/android-env.sh" ]]; then
+    source "$INSTALL_DIR/android-env.sh"
+else
+    echo "Warning: Android SDK environment setup script not found."
+    echo "Setting environment variables manually."
+    export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+    export ANDROID_HOME="$ANDROID_HOME"
+    export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$PATH"
+fi
+
+# Install Android NDK
+echo "=== Installing Android NDK $NDK_VERSION ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "ndk;$NDK_VERSION"
+
+# Verify installation
+if [[ -d "$ANDROID_NDK_HOME" ]]; then
+    echo "Android NDK $NDK_VERSION installed successfully at $ANDROID_NDK_HOME"
+else
+    echo "Error: Android NDK installation failed."
+    exit 1
+fi
+
+# Configure environment variables
+echo "=== Configuring environment variables ==="
+
+# Create environment setup script
+cat > "$INSTALL_DIR/ndk-env.sh" << EOL
+#!/bin/bash
+# Android NDK Environment Variables
+
+export ANDROID_NDK_HOME="$ANDROID_NDK_HOME"
+export PATH="\$ANDROID_NDK_HOME:\$PATH"
+EOL
+
+chmod +x "$INSTALL_DIR/ndk-env.sh"
+
+echo "Environment setup script created at $INSTALL_DIR/ndk-env.sh"
+echo "To activate Android NDK in your current shell, run:"
+echo "source \"$INSTALL_DIR/ndk-env.sh\""
+
+# Source the environment variables for the current session
+source "$INSTALL_DIR/ndk-env.sh"
+
+echo "=== Android NDK Installation Completed ==="
+echo "Android NDK $NDK_VERSION is now installed and configured."
+echo "NDK location: $ANDROID_NDK_HOME"

--- a/android-dev-setup/install-android-sdk.sh
+++ b/android-dev-setup/install-android-sdk.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Android SDK Installation Script
+# This script installs the Android SDK for development
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+ANDROID_SDK_ROOT="$INSTALL_DIR/android-sdk"
+ANDROID_HOME="$ANDROID_SDK_ROOT"
+CMDLINE_TOOLS_VERSION="11.0"
+BUILD_TOOLS_VERSION="34.0.0"
+PLATFORM_VERSION="34"
+PLATFORM_VERSION_FALLBACK="33"
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+
+echo "=== Installing Android SDK ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Starting installation at $(date)"
+echo
+
+# Function to detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macos"
+    else
+        echo "unsupported"
+    fi
+}
+
+OS_TYPE=$(detect_os)
+if [[ "$OS_TYPE" == "unsupported" ]]; then
+    echo "Unsupported operating system: $OSTYPE"
+    exit 1
+fi
+
+echo "Detected OS: $OS_TYPE"
+
+# Install Android SDK
+echo "=== Installing Android SDK Command Line Tools ==="
+
+if [[ "$OS_TYPE" == "linux" ]]; then
+    wget -O cmdline-tools.zip "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    wget -O cmdline-tools.zip "https://dl.google.com/android/repository/commandlinetools-mac-${CMDLINE_TOOLS_VERSION}_latest.zip"
+fi
+
+unzip -q cmdline-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools/temp"
+mv "$ANDROID_SDK_ROOT/cmdline-tools/temp/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+rmdir "$ANDROID_SDK_ROOT/cmdline-tools/temp"
+rm cmdline-tools.zip
+
+echo "Android SDK Command Line Tools installed at $ANDROID_SDK_ROOT/cmdline-tools/latest"
+
+# Configure environment variables
+echo "=== Configuring environment variables ==="
+
+# Create environment setup script
+cat > "$INSTALL_DIR/android-env.sh" << EOL
+#!/bin/bash
+# Android SDK Environment Variables
+
+export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+export ANDROID_HOME="$ANDROID_HOME"
+export PATH="\$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:\$ANDROID_SDK_ROOT/platform-tools:\$PATH"
+EOL
+
+chmod +x "$INSTALL_DIR/android-env.sh"
+
+echo "Environment setup script created at $INSTALL_DIR/android-env.sh"
+echo "To activate Android SDK in your current shell, run:"
+echo "source \"$INSTALL_DIR/android-env.sh\""
+
+# Source the environment variables for the current session
+source "$INSTALL_DIR/android-env.sh"
+
+# Accept licenses
+echo "=== Accepting SDK licenses ==="
+yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+# Install platform tools
+echo "=== Installing platform tools ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platform-tools"
+
+# Install build tools
+echo "=== Installing build tools $BUILD_TOOLS_VERSION ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "build-tools;$BUILD_TOOLS_VERSION"
+
+# Install platforms
+echo "=== Installing platform $PLATFORM_VERSION ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platforms;android-$PLATFORM_VERSION"
+
+echo "=== Installing platform $PLATFORM_VERSION_FALLBACK (fallback) ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platforms;android-$PLATFORM_VERSION_FALLBACK"
+
+# Install system images for emulator
+echo "=== Installing system images for emulator ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "system-images;android-$PLATFORM_VERSION;google_apis_playstore;x86_64"
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "system-images;android-$PLATFORM_VERSION;google_apis;x86_64"
+
+# Install emulator
+echo "=== Installing Android Emulator ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "emulator"
+
+# Install Google Play services
+echo "=== Installing Google Play services ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "extras;google;google_play_services"
+
+# Install sources for SDK platforms
+echo "=== Installing sources for SDK platforms ==="
+"$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "sources;android-$PLATFORM_VERSION"
+
+echo "=== Android SDK Installation Completed ==="
+echo "Android SDK is now installed and configured."
+echo "SDK location: $ANDROID_SDK_ROOT"

--- a/android-dev-setup/install-android-studio.sh
+++ b/android-dev-setup/install-android-studio.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Android Studio Installation Script
+# This script installs Android Studio for development
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+ANDROID_STUDIO_DIR="$INSTALL_DIR/android-studio"
+STUDIO_VERSION="2023.1.1.26"
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+mkdir -p "$ANDROID_STUDIO_DIR"
+
+echo "=== Installing Android Studio ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Android Studio version: $STUDIO_VERSION"
+echo "Starting installation at $(date)"
+echo
+
+# Function to detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macos"
+    else
+        echo "unsupported"
+    fi
+}
+
+OS_TYPE=$(detect_os)
+if [[ "$OS_TYPE" == "unsupported" ]]; then
+    echo "Unsupported operating system: $OSTYPE"
+    exit 1
+fi
+
+echo "Detected OS: $OS_TYPE"
+
+# Install Android Studio
+echo "=== Downloading Android Studio $STUDIO_VERSION ==="
+
+if [[ "$OS_TYPE" == "linux" ]]; then
+    wget -O android-studio.tar.gz "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/$STUDIO_VERSION/android-studio-$STUDIO_VERSION-linux.tar.gz"
+    
+    echo "=== Extracting Android Studio ==="
+    tar -xzf android-studio.tar.gz -C "$INSTALL_DIR"
+    mv "$INSTALL_DIR/android-studio"/* "$ANDROID_STUDIO_DIR"
+    rmdir "$INSTALL_DIR/android-studio"
+    rm android-studio.tar.gz
+    
+    # Create desktop entry
+    echo "=== Creating desktop entry ==="
+    mkdir -p "$HOME/.local/share/applications"
+    cat > "$HOME/.local/share/applications/android-studio.desktop" << EOL
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Android Studio
+Icon=$ANDROID_STUDIO_DIR/bin/studio.png
+Exec="$ANDROID_STUDIO_DIR/bin/studio.sh" %f
+Comment=Integrated Development Environment for Android
+Categories=Development;IDE;
+Terminal=false
+StartupWMClass=jetbrains-studio
+EOL
+    
+    echo "Desktop entry created at $HOME/.local/share/applications/android-studio.desktop"
+    
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    wget -O android-studio.dmg "https://redirector.gvt1.com/edgedl/android/studio/install/$STUDIO_VERSION/android-studio-$STUDIO_VERSION-mac.dmg"
+    echo "Please manually install Android Studio from the downloaded DMG file:"
+    echo "$INSTALL_DIR/android-studio.dmg"
+    echo "After mounting the DMG, drag Android Studio to your Applications folder."
+fi
+
+# Create launcher script
+echo "=== Creating launcher script ==="
+cat > "$INSTALL_DIR/studio.sh" << EOL
+#!/bin/bash
+# Android Studio Launcher
+
+if [[ "$OS_TYPE" == "linux" ]]; then
+    "$ANDROID_STUDIO_DIR/bin/studio.sh" "\$@"
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    open -a "Android Studio" "\$@"
+fi
+EOL
+
+chmod +x "$INSTALL_DIR/studio.sh"
+
+echo "Launcher script created at $INSTALL_DIR/studio.sh"
+echo "To launch Android Studio, run:"
+echo "$INSTALL_DIR/studio.sh"
+
+echo "=== Android Studio Installation Completed ==="
+if [[ "$OS_TYPE" == "linux" ]]; then
+    echo "Android Studio is now installed at $ANDROID_STUDIO_DIR"
+    echo "You can launch it from the application menu or by running $INSTALL_DIR/studio.sh"
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    echo "Please complete the installation by mounting the DMG and dragging Android Studio to your Applications folder."
+    echo "After installation, you can launch it from the Applications folder or by running $INSTALL_DIR/studio.sh"
+fi

--- a/android-dev-setup/install-gradle.sh
+++ b/android-dev-setup/install-gradle.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Gradle Installation Script
+# This script installs Gradle for Android development
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+GRADLE_HOME="$INSTALL_DIR/gradle"
+GRADLE_VERSION="8.4"
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+mkdir -p "$GRADLE_HOME"
+
+echo "=== Installing Gradle for Android Development ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Gradle version: $GRADLE_VERSION"
+echo "Starting installation at $(date)"
+echo
+
+# Install Gradle
+echo "=== Downloading Gradle $GRADLE_VERSION ==="
+wget -O gradle.zip "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip"
+
+echo "=== Extracting Gradle ==="
+unzip -q gradle.zip -d "$INSTALL_DIR"
+mv "$INSTALL_DIR/gradle-$GRADLE_VERSION"/* "$GRADLE_HOME"
+rmdir "$INSTALL_DIR/gradle-$GRADLE_VERSION"
+rm gradle.zip
+
+# Configure environment variables
+echo "=== Configuring environment variables ==="
+
+# Create environment setup script
+cat > "$INSTALL_DIR/gradle-env.sh" << EOL
+#!/bin/bash
+# Gradle Environment Variables
+
+export GRADLE_HOME="$GRADLE_HOME"
+export PATH="\$GRADLE_HOME/bin:\$PATH"
+EOL
+
+chmod +x "$INSTALL_DIR/gradle-env.sh"
+
+echo "Environment setup script created at $INSTALL_DIR/gradle-env.sh"
+echo "To activate Gradle in your current shell, run:"
+echo "source \"$INSTALL_DIR/gradle-env.sh\""
+
+# Source the environment variables for the current session
+source "$INSTALL_DIR/gradle-env.sh"
+
+# Verify installation
+echo "=== Verifying Gradle installation ==="
+if gradle --version; then
+    echo "Gradle $GRADLE_VERSION installed successfully at $GRADLE_HOME"
+else
+    echo "Error: Gradle installation verification failed."
+    exit 1
+fi
+
+echo "=== Gradle Installation Completed ==="
+echo "Gradle $GRADLE_VERSION is now installed and configured."

--- a/android-dev-setup/install-jdk.sh
+++ b/android-dev-setup/install-jdk.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# JDK Installation Script
+# This script installs JDK 17 (or JDK 11 as fallback) for Android development
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+JAVA_HOME="$INSTALL_DIR/jdk"
+JDK_VERSION="17"
+JDK_FALLBACK_VERSION="11"
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+mkdir -p "$JAVA_HOME"
+
+echo "=== Installing JDK for Android Development ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Starting installation at $(date)"
+echo
+
+# Function to detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macos"
+    else
+        echo "unsupported"
+    fi
+}
+
+OS_TYPE=$(detect_os)
+if [[ "$OS_TYPE" == "unsupported" ]]; then
+    echo "Unsupported operating system: $OSTYPE"
+    exit 1
+fi
+
+echo "Detected OS: $OS_TYPE"
+
+# Install JDK
+echo "=== Installing JDK $JDK_VERSION ==="
+
+if [[ "$OS_TYPE" == "linux" ]]; then
+    # Try to install JDK 17 first, fall back to JDK 11 if needed
+    if wget -q --spider "https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz"; then
+        wget -O jdk.tar.gz "https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz"
+        JDK_VERSION="17"
+    else
+        echo "JDK 17 not available, falling back to JDK 11"
+        wget -O jdk.tar.gz "https://download.oracle.com/java/11/latest/jdk-11_linux-x64_bin.tar.gz"
+        JDK_VERSION="11"
+    fi
+    
+    tar -xzf jdk.tar.gz -C "$JAVA_HOME" --strip-components=1
+    rm jdk.tar.gz
+elif [[ "$OS_TYPE" == "macos" ]]; then
+    if wget -q --spider "https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz"; then
+        wget -O jdk.tar.gz "https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz"
+        JDK_VERSION="17"
+    else
+        echo "JDK 17 not available, falling back to JDK 11"
+        wget -O jdk.tar.gz "https://download.oracle.com/java/11/latest/jdk-11_macos-x64_bin.tar.gz"
+        JDK_VERSION="11"
+    fi
+    
+    tar -xzf jdk.tar.gz -C "$JAVA_HOME" --strip-components=1
+    rm jdk.tar.gz
+fi
+
+echo "JDK $JDK_VERSION installed at $JAVA_HOME"
+"$JAVA_HOME/bin/java" -version
+
+# Configure environment variables
+echo "=== Configuring environment variables ==="
+
+# Create environment setup script
+cat > "$INSTALL_DIR/java-env.sh" << EOL
+#!/bin/bash
+# Java Environment Variables
+
+export JAVA_HOME="$JAVA_HOME"
+export PATH="\$JAVA_HOME/bin:\$PATH"
+EOL
+
+chmod +x "$INSTALL_DIR/java-env.sh"
+
+echo "Environment setup script created at $INSTALL_DIR/java-env.sh"
+echo "To activate Java in your current shell, run:"
+echo "source \"$INSTALL_DIR/java-env.sh\""
+
+# Source the environment variables for the current session
+source "$INSTALL_DIR/java-env.sh"
+
+echo "=== JDK Installation Completed ==="
+echo "JDK $JDK_VERSION is now installed and configured."

--- a/android-dev-setup/setup-all.sh
+++ b/android-dev-setup/setup-all.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Complete Android Development Environment Setup Script
+# This script sets up a complete Android development environment
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+
+echo "=== Android Development Environment Setup ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Starting setup at $(date)"
+echo
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+# Make all scripts executable
+chmod +x /workspace/android-dev-setup/*.sh
+
+# Install JDK
+echo "=== Step 1: Installing JDK ==="
+/workspace/android-dev-setup/install-jdk.sh "$INSTALL_DIR"
+source "$INSTALL_DIR/java-env.sh"
+echo
+
+# Install Android SDK
+echo "=== Step 2: Installing Android SDK ==="
+/workspace/android-dev-setup/install-android-sdk.sh "$INSTALL_DIR"
+source "$INSTALL_DIR/android-env.sh"
+echo
+
+# Install Android NDK
+echo "=== Step 3: Installing Android NDK ==="
+/workspace/android-dev-setup/install-android-ndk.sh "$INSTALL_DIR"
+source "$INSTALL_DIR/ndk-env.sh"
+echo
+
+# Install Gradle
+echo "=== Step 4: Installing Gradle ==="
+/workspace/android-dev-setup/install-gradle.sh "$INSTALL_DIR"
+source "$INSTALL_DIR/gradle-env.sh"
+echo
+
+# Install Android Studio
+echo "=== Step 5: Installing Android Studio ==="
+/workspace/android-dev-setup/install-android-studio.sh "$INSTALL_DIR"
+echo
+
+# Create AVD
+echo "=== Step 6: Creating Android Virtual Device ==="
+/workspace/android-dev-setup/create-avd.sh "$INSTALL_DIR"
+echo
+
+# Combine environment scripts
+echo "=== Combining environment scripts ==="
+cat > "$INSTALL_DIR/env-setup.sh" << EOL
+#!/bin/bash
+# Android Development Environment Variables
+
+# Java
+$(cat "$INSTALL_DIR/java-env.sh" | grep -v "#!/bin/bash")
+
+# Android SDK
+$(cat "$INSTALL_DIR/android-env.sh" | grep -v "#!/bin/bash")
+
+# Android NDK
+$(cat "$INSTALL_DIR/ndk-env.sh" | grep -v "#!/bin/bash")
+
+# Gradle
+$(cat "$INSTALL_DIR/gradle-env.sh" | grep -v "#!/bin/bash")
+
+# Add to PATH (avoid duplicates)
+export PATH="\$JAVA_HOME/bin:\$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:\$ANDROID_SDK_ROOT/platform-tools:\$ANDROID_SDK_ROOT/emulator:\$ANDROID_NDK_HOME:\$GRADLE_HOME/bin:\$PATH"
+EOL
+
+chmod +x "$INSTALL_DIR/env-setup.sh"
+
+# Add to shell profile
+if [[ -f "$HOME/.bashrc" ]]; then
+    echo "source \"$INSTALL_DIR/env-setup.sh\"" >> "$HOME/.bashrc"
+    echo "Environment variables added to .bashrc"
+fi
+
+if [[ -f "$HOME/.zshrc" ]]; then
+    echo "source \"$INSTALL_DIR/env-setup.sh\"" >> "$HOME/.zshrc"
+    echo "Environment variables added to .zshrc"
+fi
+
+if [[ -f "$HOME/.bash_profile" ]]; then
+    echo "source \"$INSTALL_DIR/env-setup.sh\"" >> "$HOME/.bash_profile"
+    echo "Environment variables added to .bash_profile"
+fi
+
+# Source the environment variables for the current session
+source "$INSTALL_DIR/env-setup.sh"
+
+# Validate installation
+echo "=== Validating installation ==="
+
+# Check Java
+if "$JAVA_HOME/bin/java" -version; then
+    echo "✓ Java is installed and working."
+else
+    echo "✗ Java installation failed."
+fi
+
+# Check Android SDK
+if [[ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]]; then
+    echo "✓ Android SDK is installed."
+else
+    echo "✗ Android SDK installation failed."
+fi
+
+# Check Android NDK
+if [[ -d "$ANDROID_NDK_HOME" ]]; then
+    echo "✓ Android NDK is installed."
+else
+    echo "✗ Android NDK installation failed."
+fi
+
+# Check Gradle
+if "$GRADLE_HOME/bin/gradle" --version; then
+    echo "✓ Gradle is installed and working."
+else
+    echo "✗ Gradle installation failed."
+fi
+
+# Check Android Studio
+if [[ -d "$ANDROID_STUDIO_DIR" ]]; then
+    echo "✓ Android Studio is installed."
+else
+    echo "✗ Android Studio installation failed."
+fi
+
+# Check environment variables
+if [[ -n "$ANDROID_SDK_ROOT" && -n "$JAVA_HOME" && -n "$GRADLE_HOME" ]]; then
+    echo "✓ Environment variables are set."
+else
+    echo "✗ Environment variables are not set correctly."
+fi
+
+# Generate summary report
+echo "=== Android Development Environment Summary ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "JDK: $JAVA_HOME"
+echo "Android SDK: $ANDROID_SDK_ROOT"
+echo "Android NDK: $ANDROID_NDK_HOME"
+echo "Gradle: $GRADLE_HOME"
+echo "Android Studio: $ANDROID_STUDIO_DIR"
+echo
+echo "Environment setup script: $INSTALL_DIR/env-setup.sh"
+echo
+echo "To activate the environment in a new terminal, run:"
+echo "source \"$INSTALL_DIR/env-setup.sh\""
+echo
+echo "To launch Android Studio, run:"
+echo "$INSTALL_DIR/studio.sh"
+echo
+echo "To launch the Android emulator, run:"
+echo "$INSTALL_DIR/launch-emulator.sh"
+echo
+echo "Setup completed at $(date)"
+
+echo "=== Android Development Environment Setup Completed ==="
+echo "Please restart your terminal or run 'source \"$INSTALL_DIR/env-setup.sh\"' to apply the environment variables."

--- a/android-dev-setup/setup.sh
+++ b/android-dev-setup/setup.sh
@@ -1,0 +1,386 @@
+#!/bin/bash
+# Android Development Environment Setup Script
+# This script sets up a complete Android development environment
+# including JDK, Android SDK, NDK, Gradle, and Android Studio
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="$HOME/android-dev"
+ANDROID_SDK_ROOT="$INSTALL_DIR/android-sdk"
+ANDROID_HOME="$ANDROID_SDK_ROOT"
+ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/25.2.9519653"
+ANDROID_STUDIO_DIR="$INSTALL_DIR/android-studio"
+GRADLE_HOME="$INSTALL_DIR/gradle"
+JAVA_HOME="$INSTALL_DIR/jdk"
+CMDLINE_TOOLS_VERSION="11.0"
+BUILD_TOOLS_VERSION="34.0.0"
+PLATFORM_VERSION="34"
+PLATFORM_VERSION_FALLBACK="33"
+NDK_VERSION="25.2.9519653"
+GRADLE_VERSION="8.4"
+JDK_VERSION="17"
+JDK_FALLBACK_VERSION="11"
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+echo "=== Android Development Environment Setup ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Starting setup at $(date)"
+echo
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macos"
+    else
+        echo "unsupported"
+    fi
+}
+
+OS_TYPE=$(detect_os)
+if [[ "$OS_TYPE" == "unsupported" ]]; then
+    echo "Unsupported operating system: $OSTYPE"
+    exit 1
+fi
+
+echo "Detected OS: $OS_TYPE"
+
+# Install required packages
+install_dependencies() {
+    echo "=== Installing system dependencies ==="
+    
+    if [[ "$OS_TYPE" == "linux" ]]; then
+        if command_exists apt-get; then
+            sudo apt-get update
+            sudo apt-get install -y wget unzip zip curl git build-essential \
+                libz-dev libncurses-dev libbz2-dev liblzma-dev \
+                libssl-dev libreadline-dev libsqlite3-dev \
+                libgl1-mesa-dev libxrandr-dev libxxf86vm-dev \
+                libxinerama-dev libxcursor-dev libxi-dev
+        elif command_exists dnf; then
+            sudo dnf install -y wget unzip zip curl git gcc gcc-c++ make \
+                zlib-devel ncurses-devel bzip2-devel xz-devel \
+                openssl-devel readline-devel sqlite-devel \
+                mesa-libGL-devel libXrandr-devel libXxf86vm-devel \
+                libXinerama-devel libXcursor-devel libXi-devel
+        else
+            echo "Unsupported Linux distribution. Please install the following packages manually:"
+            echo "wget, unzip, zip, curl, git, build tools, and development libraries"
+        fi
+        
+        # Install KVM for emulator acceleration
+        if command_exists apt-get; then
+            sudo apt-get install -y qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils
+            sudo adduser $USER kvm
+            sudo adduser $USER libvirt
+        elif command_exists dnf; then
+            sudo dnf install -y qemu-kvm libvirt virt-install bridge-utils
+            sudo usermod -aG kvm $USER
+            sudo usermod -aG libvirt $USER
+        fi
+    elif [[ "$OS_TYPE" == "macos" ]]; then
+        if ! command_exists brew; then
+            echo "Installing Homebrew..."
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        fi
+        
+        brew install wget unzip zip curl git
+    fi
+    
+    echo "System dependencies installed."
+}
+
+# Install JDK
+install_jdk() {
+    echo "=== Installing JDK $JDK_VERSION ==="
+    mkdir -p "$JAVA_HOME"
+    
+    if [[ "$OS_TYPE" == "linux" ]]; then
+        # Try to install JDK 17 first, fall back to JDK 11 if needed
+        if wget -q --spider "https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz"; then
+            wget -O jdk.tar.gz "https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.tar.gz"
+            JDK_VERSION="17"
+        else
+            echo "JDK 17 not available, falling back to JDK 11"
+            wget -O jdk.tar.gz "https://download.oracle.com/java/11/latest/jdk-11_linux-x64_bin.tar.gz"
+            JDK_VERSION="11"
+        fi
+        
+        tar -xzf jdk.tar.gz -C "$JAVA_HOME" --strip-components=1
+        rm jdk.tar.gz
+    elif [[ "$OS_TYPE" == "macos" ]]; then
+        if wget -q --spider "https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz"; then
+            wget -O jdk.tar.gz "https://download.oracle.com/java/17/latest/jdk-17_macos-x64_bin.tar.gz"
+            JDK_VERSION="17"
+        else
+            echo "JDK 17 not available, falling back to JDK 11"
+            wget -O jdk.tar.gz "https://download.oracle.com/java/11/latest/jdk-11_macos-x64_bin.tar.gz"
+            JDK_VERSION="11"
+        fi
+        
+        tar -xzf jdk.tar.gz -C "$JAVA_HOME" --strip-components=1
+        rm jdk.tar.gz
+    fi
+    
+    echo "JDK $JDK_VERSION installed at $JAVA_HOME"
+    "$JAVA_HOME/bin/java" -version
+}
+
+# Install Android SDK
+install_android_sdk() {
+    echo "=== Installing Android SDK ==="
+    mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+    
+    if [[ "$OS_TYPE" == "linux" ]]; then
+        wget -O cmdline-tools.zip "https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+    elif [[ "$OS_TYPE" == "macos" ]]; then
+        wget -O cmdline-tools.zip "https://dl.google.com/android/repository/commandlinetools-mac-${CMDLINE_TOOLS_VERSION}_latest.zip"
+    fi
+    
+    unzip -q cmdline-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools/temp"
+    mv "$ANDROID_SDK_ROOT/cmdline-tools/temp/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+    rmdir "$ANDROID_SDK_ROOT/cmdline-tools/temp"
+    rm cmdline-tools.zip
+    
+    echo "Android SDK Command Line Tools installed at $ANDROID_SDK_ROOT/cmdline-tools/latest"
+    
+    # Accept licenses
+    yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses
+    
+    # Install platform tools
+    echo "Installing platform tools..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platform-tools"
+    
+    # Install build tools
+    echo "Installing build tools $BUILD_TOOLS_VERSION..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "build-tools;$BUILD_TOOLS_VERSION"
+    
+    # Install platforms
+    echo "Installing platform $PLATFORM_VERSION..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platforms;android-$PLATFORM_VERSION"
+    
+    echo "Installing platform $PLATFORM_VERSION_FALLBACK (fallback)..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platforms;android-$PLATFORM_VERSION_FALLBACK"
+    
+    # Install system images for emulator
+    echo "Installing system images for emulator..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "system-images;android-$PLATFORM_VERSION;google_apis_playstore;x86_64"
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "system-images;android-$PLATFORM_VERSION;google_apis;x86_64"
+    
+    # Install emulator
+    echo "Installing Android Emulator..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "emulator"
+    
+    # Install Google Play services
+    echo "Installing Google Play services..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "extras;google;google_play_services"
+    
+    # Install sources for SDK platforms
+    echo "Installing sources for SDK platforms..."
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "sources;android-$PLATFORM_VERSION"
+    
+    echo "Android SDK components installed successfully."
+}
+
+# Install Android NDK
+install_android_ndk() {
+    echo "=== Installing Android NDK $NDK_VERSION ==="
+    
+    "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "ndk;$NDK_VERSION"
+    
+    echo "Android NDK $NDK_VERSION installed at $ANDROID_NDK_HOME"
+}
+
+# Install Gradle
+install_gradle() {
+    echo "=== Installing Gradle $GRADLE_VERSION ==="
+    mkdir -p "$GRADLE_HOME"
+    
+    wget -O gradle.zip "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip"
+    unzip -q gradle.zip -d "$INSTALL_DIR"
+    mv "$INSTALL_DIR/gradle-$GRADLE_VERSION"/* "$GRADLE_HOME"
+    rmdir "$INSTALL_DIR/gradle-$GRADLE_VERSION"
+    rm gradle.zip
+    
+    echo "Gradle $GRADLE_VERSION installed at $GRADLE_HOME"
+    "$GRADLE_HOME/bin/gradle" --version
+}
+
+# Install Android Studio
+install_android_studio() {
+    echo "=== Installing Android Studio ==="
+    mkdir -p "$ANDROID_STUDIO_DIR"
+    
+    if [[ "$OS_TYPE" == "linux" ]]; then
+        wget -O android-studio.tar.gz "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2023.1.1.26/android-studio-2023.1.1.26-linux.tar.gz"
+        tar -xzf android-studio.tar.gz -C "$INSTALL_DIR"
+        mv "$INSTALL_DIR/android-studio"/* "$ANDROID_STUDIO_DIR"
+        rmdir "$INSTALL_DIR/android-studio"
+        rm android-studio.tar.gz
+    elif [[ "$OS_TYPE" == "macos" ]]; then
+        wget -O android-studio.dmg "https://redirector.gvt1.com/edgedl/android/studio/install/2023.1.1.26/android-studio-2023.1.1.26-mac.dmg"
+        echo "Please manually install Android Studio from the downloaded DMG file:"
+        echo "$INSTALL_DIR/android-studio.dmg"
+    fi
+    
+    echo "Android Studio installed at $ANDROID_STUDIO_DIR"
+}
+
+# Configure environment variables
+configure_environment() {
+    echo "=== Configuring environment variables ==="
+    
+    # Create environment setup script
+    cat > "$INSTALL_DIR/env-setup.sh" << EOL
+#!/bin/bash
+# Android Development Environment Variables
+
+export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
+export ANDROID_HOME="$ANDROID_HOME"
+export ANDROID_NDK_HOME="$ANDROID_NDK_HOME"
+export JAVA_HOME="$JAVA_HOME"
+export GRADLE_HOME="$GRADLE_HOME"
+
+export PATH="\$JAVA_HOME/bin:\$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:\$ANDROID_SDK_ROOT/platform-tools:\$ANDROID_NDK_HOME:\$GRADLE_HOME/bin:\$PATH"
+EOL
+    
+    chmod +x "$INSTALL_DIR/env-setup.sh"
+    
+    # Add to shell profile
+    if [[ "$OS_TYPE" == "linux" ]]; then
+        if [[ -f "$HOME/.bashrc" ]]; then
+            echo "source \"$INSTALL_DIR/env-setup.sh\"" >> "$HOME/.bashrc"
+            echo "Environment variables added to .bashrc"
+        fi
+        
+        if [[ -f "$HOME/.zshrc" ]]; then
+            echo "source \"$INSTALL_DIR/env-setup.sh\"" >> "$HOME/.zshrc"
+            echo "Environment variables added to .zshrc"
+        fi
+    elif [[ "$OS_TYPE" == "macos" ]]; then
+        if [[ -f "$HOME/.bash_profile" ]]; then
+            echo "source \"$INSTALL_DIR/env-setup.sh\"" >> "$HOME/.bash_profile"
+            echo "Environment variables added to .bash_profile"
+        fi
+        
+        if [[ -f "$HOME/.zshrc" ]]; then
+            echo "source \"$INSTALL_DIR/env-setup.sh\"" >> "$HOME/.zshrc"
+            echo "Environment variables added to .zshrc"
+        fi
+    fi
+    
+    # Source the environment variables for the current session
+    source "$INSTALL_DIR/env-setup.sh"
+    
+    echo "Environment variables configured."
+}
+
+# Create AVD for testing
+create_avd() {
+    echo "=== Creating Android Virtual Device (AVD) ==="
+    
+    # Create a default AVD for testing
+    echo "no" | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager" create avd \
+        -n "test_avd" \
+        -k "system-images;android-$PLATFORM_VERSION;google_apis_playstore;x86_64" \
+        -d "pixel_5"
+    
+    echo "AVD 'test_avd' created for testing."
+}
+
+# Validate installation
+validate_installation() {
+    echo "=== Validating installation ==="
+    
+    # Check Java
+    if "$JAVA_HOME/bin/java" -version; then
+        echo "✓ Java is installed and working."
+    else
+        echo "✗ Java installation failed."
+    fi
+    
+    # Check Android SDK
+    if [[ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]]; then
+        echo "✓ Android SDK is installed."
+    else
+        echo "✗ Android SDK installation failed."
+    fi
+    
+    # Check Android NDK
+    if [[ -d "$ANDROID_NDK_HOME" ]]; then
+        echo "✓ Android NDK is installed."
+    else
+        echo "✗ Android NDK installation failed."
+    fi
+    
+    # Check Gradle
+    if "$GRADLE_HOME/bin/gradle" --version; then
+        echo "✓ Gradle is installed and working."
+    else
+        echo "✗ Gradle installation failed."
+    fi
+    
+    # Check Android Studio
+    if [[ -d "$ANDROID_STUDIO_DIR" ]]; then
+        echo "✓ Android Studio is installed."
+    else
+        echo "✗ Android Studio installation failed."
+    fi
+    
+    # Check environment variables
+    if [[ -n "$ANDROID_SDK_ROOT" && -n "$JAVA_HOME" && -n "$GRADLE_HOME" ]]; then
+        echo "✓ Environment variables are set."
+    else
+        echo "✗ Environment variables are not set correctly."
+    fi
+    
+    echo "Installation validation completed."
+}
+
+# Generate summary report
+generate_summary() {
+    echo "=== Android Development Environment Summary ==="
+    echo "Installation directory: $INSTALL_DIR"
+    echo "JDK version: $JDK_VERSION"
+    echo "Android SDK: $ANDROID_SDK_ROOT"
+    echo "Android NDK: $ANDROID_NDK_HOME"
+    echo "Gradle: $GRADLE_HOME"
+    echo "Android Studio: $ANDROID_STUDIO_DIR"
+    echo
+    echo "Environment setup script: $INSTALL_DIR/env-setup.sh"
+    echo
+    echo "To activate the environment in a new terminal, run:"
+    echo "source \"$INSTALL_DIR/env-setup.sh\""
+    echo
+    echo "Setup completed at $(date)"
+}
+
+# Main installation process
+main() {
+    install_dependencies
+    install_jdk
+    install_android_sdk
+    install_android_ndk
+    install_gradle
+    install_android_studio
+    configure_environment
+    create_avd
+    validate_installation
+    generate_summary
+    
+    echo "=== Android Development Environment Setup Completed ==="
+    echo "Please restart your terminal or run 'source \"$INSTALL_DIR/env-setup.sh\"' to apply the environment variables."
+}
+
+# Run the main installation process
+main

--- a/android-dev-setup/validate-environment.sh
+++ b/android-dev-setup/validate-environment.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Android Development Environment Validation Script
+# This script validates the Android development environment
+
+set -e  # Exit on error
+
+# Configuration variables
+INSTALL_DIR="${1:-$HOME/android-dev}"
+JAVA_HOME="$INSTALL_DIR/jdk"
+ANDROID_SDK_ROOT="$INSTALL_DIR/android-sdk"
+ANDROID_HOME="$ANDROID_SDK_ROOT"
+ANDROID_NDK_HOME="$ANDROID_SDK_ROOT/ndk/25.2.9519653"
+GRADLE_HOME="$INSTALL_DIR/gradle"
+ANDROID_STUDIO_DIR="$INSTALL_DIR/android-studio"
+
+echo "=== Android Development Environment Validation ==="
+echo "Installation directory: $INSTALL_DIR"
+echo "Starting validation at $(date)"
+echo
+
+# Source environment variables if available
+if [[ -f "$INSTALL_DIR/env-setup.sh" ]]; then
+    source "$INSTALL_DIR/env-setup.sh"
+    echo "Environment variables loaded from $INSTALL_DIR/env-setup.sh"
+else
+    echo "Warning: Environment setup script not found at $INSTALL_DIR/env-setup.sh"
+    echo "Using default environment variables."
+fi
+
+# Validate JDK
+echo "=== Validating JDK ==="
+if [[ -d "$JAVA_HOME" ]]; then
+    echo "JDK directory exists at $JAVA_HOME"
+    
+    if "$JAVA_HOME/bin/java" -version; then
+        echo "✓ Java is installed and working."
+    else
+        echo "✗ Java installation failed or not in PATH."
+    fi
+else
+    echo "✗ JDK directory not found at $JAVA_HOME"
+fi
+echo
+
+# Validate Android SDK
+echo "=== Validating Android SDK ==="
+if [[ -d "$ANDROID_SDK_ROOT" ]]; then
+    echo "Android SDK directory exists at $ANDROID_SDK_ROOT"
+    
+    if [[ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]]; then
+        echo "✓ Android SDK Command Line Tools are installed."
+        
+        echo "Installed packages:"
+        "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --list_installed | grep -v "Available"
+    else
+        echo "✗ Android SDK Command Line Tools not found."
+    fi
+    
+    if [[ -d "$ANDROID_SDK_ROOT/platform-tools" ]]; then
+        echo "✓ Platform tools are installed."
+        
+        if [[ -f "$ANDROID_SDK_ROOT/platform-tools/adb" ]]; then
+            echo "ADB version:"
+            "$ANDROID_SDK_ROOT/platform-tools/adb" --version
+        fi
+    else
+        echo "✗ Platform tools not found."
+    fi
+    
+    if [[ -d "$ANDROID_SDK_ROOT/build-tools" ]]; then
+        echo "✓ Build tools are installed."
+        echo "Available build tools versions:"
+        ls -1 "$ANDROID_SDK_ROOT/build-tools"
+    else
+        echo "✗ Build tools not found."
+    fi
+    
+    if [[ -d "$ANDROID_SDK_ROOT/platforms" ]]; then
+        echo "✓ Android platforms are installed."
+        echo "Available platform versions:"
+        ls -1 "$ANDROID_SDK_ROOT/platforms"
+    else
+        echo "✗ Android platforms not found."
+    fi
+else
+    echo "✗ Android SDK directory not found at $ANDROID_SDK_ROOT"
+fi
+echo
+
+# Validate Android NDK
+echo "=== Validating Android NDK ==="
+if [[ -d "$ANDROID_NDK_HOME" ]]; then
+    echo "✓ Android NDK directory exists at $ANDROID_NDK_HOME"
+    
+    if [[ -f "$ANDROID_NDK_HOME/ndk-build" ]]; then
+        echo "✓ NDK build tool is available."
+    else
+        echo "✗ NDK build tool not found."
+    fi
+    
+    if [[ -f "$ANDROID_NDK_HOME/source.properties" ]]; then
+        echo "NDK version:"
+        cat "$ANDROID_NDK_HOME/source.properties" | grep "Pkg.Revision"
+    fi
+else
+    echo "✗ Android NDK directory not found at $ANDROID_NDK_HOME"
+fi
+echo
+
+# Validate Gradle
+echo "=== Validating Gradle ==="
+if [[ -d "$GRADLE_HOME" ]]; then
+    echo "✓ Gradle directory exists at $GRADLE_HOME"
+    
+    if "$GRADLE_HOME/bin/gradle" --version; then
+        echo "✓ Gradle is installed and working."
+    else
+        echo "✗ Gradle installation failed or not in PATH."
+    fi
+else
+    echo "✗ Gradle directory not found at $GRADLE_HOME"
+fi
+echo
+
+# Validate Android Studio
+echo "=== Validating Android Studio ==="
+if [[ -d "$ANDROID_STUDIO_DIR" ]]; then
+    echo "✓ Android Studio directory exists at $ANDROID_STUDIO_DIR"
+    
+    if [[ -f "$ANDROID_STUDIO_DIR/bin/studio.sh" ]]; then
+        echo "✓ Android Studio launcher is available."
+    else
+        echo "✗ Android Studio launcher not found."
+    fi
+else
+    echo "✗ Android Studio directory not found at $ANDROID_STUDIO_DIR"
+fi
+echo
+
+# Validate AVD
+echo "=== Validating Android Virtual Devices ==="
+if [[ -d "$HOME/.android/avd" ]]; then
+    echo "✓ AVD directory exists at $HOME/.android/avd"
+    
+    if [[ -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager" ]]; then
+        echo "Available AVDs:"
+        "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager" list avd
+    else
+        echo "✗ AVD manager not found."
+    fi
+else
+    echo "✗ AVD directory not found at $HOME/.android/avd"
+fi
+echo
+
+# Validate environment variables
+echo "=== Validating Environment Variables ==="
+if [[ -n "$JAVA_HOME" ]]; then
+    echo "✓ JAVA_HOME is set to $JAVA_HOME"
+else
+    echo "✗ JAVA_HOME is not set."
+fi
+
+if [[ -n "$ANDROID_SDK_ROOT" ]]; then
+    echo "✓ ANDROID_SDK_ROOT is set to $ANDROID_SDK_ROOT"
+else
+    echo "✗ ANDROID_SDK_ROOT is not set."
+fi
+
+if [[ -n "$ANDROID_HOME" ]]; then
+    echo "✓ ANDROID_HOME is set to $ANDROID_HOME"
+else
+    echo "✗ ANDROID_HOME is not set."
+fi
+
+if [[ -n "$ANDROID_NDK_HOME" ]]; then
+    echo "✓ ANDROID_NDK_HOME is set to $ANDROID_NDK_HOME"
+else
+    echo "✗ ANDROID_NDK_HOME is not set."
+fi
+
+if [[ -n "$GRADLE_HOME" ]]; then
+    echo "✓ GRADLE_HOME is set to $GRADLE_HOME"
+else
+    echo "✗ GRADLE_HOME is not set."
+fi
+echo
+
+# Check PATH
+echo "=== Validating PATH ==="
+if echo "$PATH" | grep -q "$JAVA_HOME/bin"; then
+    echo "✓ JAVA_HOME/bin is in PATH"
+else
+    echo "✗ JAVA_HOME/bin is not in PATH."
+fi
+
+if echo "$PATH" | grep -q "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"; then
+    echo "✓ Android SDK Command Line Tools are in PATH"
+else
+    echo "✗ Android SDK Command Line Tools are not in PATH."
+fi
+
+if echo "$PATH" | grep -q "$ANDROID_SDK_ROOT/platform-tools"; then
+    echo "✓ Android Platform Tools are in PATH"
+else
+    echo "✗ Android Platform Tools are not in PATH."
+fi
+
+if echo "$PATH" | grep -q "$ANDROID_NDK_HOME"; then
+    echo "✓ Android NDK is in PATH"
+else
+    echo "✗ Android NDK is not in PATH."
+fi
+
+if echo "$PATH" | grep -q "$GRADLE_HOME/bin"; then
+    echo "✓ Gradle is in PATH"
+else
+    echo "✗ Gradle is not in PATH."
+fi
+echo
+
+# Summary
+echo "=== Validation Summary ==="
+echo "JDK: $(if [[ -d "$JAVA_HOME" && -f "$JAVA_HOME/bin/java" ]]; then echo "✓"; else echo "✗"; fi)"
+echo "Android SDK: $(if [[ -d "$ANDROID_SDK_ROOT" && -f "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]]; then echo "✓"; else echo "✗"; fi)"
+echo "Android NDK: $(if [[ -d "$ANDROID_NDK_HOME" ]]; then echo "✓"; else echo "✗"; fi)"
+echo "Gradle: $(if [[ -d "$GRADLE_HOME" && -f "$GRADLE_HOME/bin/gradle" ]]; then echo "✓"; else echo "✗"; fi)"
+echo "Android Studio: $(if [[ -d "$ANDROID_STUDIO_DIR" ]]; then echo "✓"; else echo "✗"; fi)"
+echo "Environment Variables: $(if [[ -n "$JAVA_HOME" && -n "$ANDROID_SDK_ROOT" && -n "$ANDROID_HOME" && -n "$ANDROID_NDK_HOME" && -n "$GRADLE_HOME" ]]; then echo "✓"; else echo "✗"; fi)"
+echo
+
+echo "=== Validation Completed at $(date) ==="


### PR DESCRIPTION
## Description
This PR adds a complete Android development environment setup to support the VrxTheater app development. The setup includes scripts and configurations for installing and configuring all necessary components for Android development, including JDK, Android SDK, NDK, Gradle, and Android Studio.

## Features
- Complete setup scripts for all Android development components
- Support for both local development and CI/CD pipelines
- Docker configuration for containerized development
- GitHub Actions workflow for CI/CD integration
- Validation scripts to ensure proper installation
- Comprehensive documentation

## Components Included
- JDK 17 (with JDK 11 fallback)
- Android SDK with latest command line tools
- Android platforms 34 and 33
- Android build tools 34.0.0
- Android NDK 25.2.9519653
- Gradle 8.4
- Android Studio 2023.1.1.26
- Android Emulator with system images
- AVD creation and configuration

## How to Use
To set up the complete Android development environment, run:
```bash
chmod +x android-dev-setup/setup-all.sh
android-dev-setup/setup-all.sh [INSTALL_DIR]
```

After installation, activate the environment variables:
```bash
source "$INSTALL_DIR/env-setup.sh"
```

## Testing
The setup has been tested on:
- Ubuntu 22.04
- macOS environments

## Documentation
- README.md with detailed instructions
- SUMMARY.md with component overview
- Docker usage documentation
- CI/CD integration guide

This PR addresses the need for a standardized, reproducible Android development environment to support the VrxTheater app development.